### PR TITLE
Lower CPU overhead in decode loop -> reaching 410 toks/s/user on Llama 3 8b with 4x MI300x

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The numbers are changing at every commit, try it out by yourself!
 
 But if you can't, here are approximate performance numbers on a small prompt, generating 256 tokens:
 * Llama 3 8B, fp16 on 1x MI300x: 210 tokens/s/user
-* Llama 3 8B, fp16 on 4x MI300x: 350 tokens/s/user
+* Llama 3 8B, fp16 on 4x MI300x: 410 tokens/s/user
 * Llama 4 Scout, bf16 on 4x MI300x: 190 tokens/s/user
 
 TODO: MI100 results, comparison to Nvidia TensorRT, HuggingFace stock + compiled stock performance

--- a/csrc/embedding/embedding.cu
+++ b/csrc/embedding/embedding.cu
@@ -1,0 +1,125 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+#include "embedding.cuh"
+
+#include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
+
+void muillm_embedding_forward_xx16_indices_i32(
+  hipStream_t stream,
+  unsigned N,
+  unsigned E,
+  const uint16_t* weights,
+  const uint32_t* x,
+  uint16_t* out_embeddings,
+  int simd_lanes
+);
+
+void muillm_embedding_forward_xx16_indices_i64(
+  hipStream_t stream,
+  unsigned N,
+  unsigned E,
+  const uint16_t* weights,
+  const uint64_t* x,
+  uint16_t* out_embeddings,
+  int simd_lanes
+);
+
+#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+
+void muillm_embedding_forward_placed_output(
+    muillm_engine_t* engine,
+    torch::Tensor& weights,
+    torch::Tensor& x,
+    void* output_ptr,
+    hipStream_t stream) {
+  CHECK_INPUT(weights);
+  CHECK_INPUT(x);
+
+  auto embed_dtype = weights.dtype();
+  auto index_dtype = x.dtype();
+
+  // N is the number of embeddings to copy, which
+  // is the number of elements in c
+  const auto N = x.numel();
+  const auto E = weights.size(1);
+
+  int simd_lanes = engine->gpu_infos[0]->simd_lanes;
+
+  // try to occupy enough to saturate memory bandwidth
+  /*
+  while ((num_blocks * threads_per_blocks < 8 * simd_lanes) && threads_per_blocks < 256) {
+    threads_per_blocks *= 2;
+  }
+  */
+
+  if (embed_dtype == torch::kFloat16 || embed_dtype == torch::kBFloat16) {
+    if (index_dtype == torch::kInt32) {
+      muillm_embedding_forward_xx16_indices_i32(
+        stream,
+        N,
+        E,
+        (const uint16_t*)weights.data_ptr(),
+        (const uint32_t*)x.data_ptr(),
+        (uint16_t*) output_ptr,
+        simd_lanes
+      );
+    } else if (index_dtype == torch::kInt64) {
+      muillm_embedding_forward_xx16_indices_i64(
+        stream,
+        N,
+        E,
+        (const uint16_t*)weights.data_ptr(),
+        (const uint64_t*)x.data_ptr(),
+        (uint16_t*) output_ptr,
+        simd_lanes
+      );
+    } else {
+      TORCH_CHECK(false, "Unsupported index dtype for embedding_forward");
+    }
+  } else {
+    TORCH_CHECK(false, "Unsupported embedding dtype for embedding_forward");
+  }
+}
+
+at::Tensor muillm_embedding_forward(
+    muillm_engine_t* engine,
+    torch::Tensor& weights,
+    torch::Tensor& x) {
+  CHECK_INPUT(x);
+
+  auto device = x.device();
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+
+  const auto E = weights.size(1);
+
+  auto embed_dtype = weights.dtype();
+  auto output_options = at::TensorOptions()
+                            .dtype(embed_dtype)
+                            .layout(at::kStrided)
+                            .device(device) // same output device as inputs
+                            .requires_grad(false);
+
+  // y has the same dimensions as x, except the last dim that is given by
+  // the embedding size
+  auto output_sizes = x.sizes().vec();
+  output_sizes.push_back(E);
+
+  auto y = torch::empty(output_sizes, output_options);
+
+  void* output_ptr = y.data_ptr();
+
+  // call with the placed output
+  muillm_embedding_forward_placed_output(
+    engine,
+    weights,
+    x,
+    output_ptr,
+    stream
+  );
+
+  return y;
+}

--- a/csrc/embedding/embedding.cuh
+++ b/csrc/embedding/embedding.cuh
@@ -1,0 +1,24 @@
+#ifndef __MUILLM_EMBEDDING_KERNELS_CUH__
+#define __MUILLM_EMBEDDING_KERNELS_CUH__
+
+#include "../engine.h"
+
+#include <torch/extension.h>
+
+// variant where the output needs to be placed somewhere precise
+// (used when fusing reductions)
+void muillm_embedding_forward_placed_output(
+    muillm_engine_t* engine,
+    torch::Tensor& weights,
+    torch::Tensor& inputs,
+    void* output_ptr,
+    hipStream_t stream
+);
+
+at::Tensor muillm_embedding_forward(
+    muillm_engine_t* engine,
+    torch::Tensor& weights,
+    torch::Tensor& inputs
+);
+
+#endif // __MUILLM_EMBEDDING_KERNELS_CUH__

--- a/csrc/embedding/embedding_xx16_kernels.cu
+++ b/csrc/embedding/embedding_xx16_kernels.cu
@@ -1,0 +1,118 @@
+#include <hip/hip_fp16.h>
+
+#include <stdint.h>
+
+typedef uint16_t xx16;
+
+#define THREADS_PER_BLOCK 256
+
+template <typename T>
+static inline const T* __device__ addr(const T* p, unsigned index) {
+  // helps the AMDGPU compiler understand it can use the sgrp pair + single vgpr addressing mode
+  unsigned byte_offset = sizeof(T) * index;
+  const uint8_t* p8 = (const uint8_t*)p;
+  return (const T*) (p8 + byte_offset);
+}
+
+template <typename T>
+static inline T* __device__ addr(T* p, unsigned index) {
+  // helps the AMDGPU compiler understand it can use the sgrp pair + single vgpr addressing mode
+  unsigned byte_offset = sizeof(T) * index;
+  uint8_t* p8 = (uint8_t*)p;
+  return (T*) (p8 + byte_offset);
+}
+
+// expected block dimensions: [x=N]
+__global__ void embedding_forward_xx16_indices_i32_kernel(
+  // inputs
+  const uint16_t* embedding_weights,
+  const uint32_t* indices,
+  // outputs
+  uint16_t* out_embeddings,
+  // other arguments
+  unsigned E
+) {
+  // one block copies one embedding
+  unsigned idx = blockIdx.x;
+
+  uint32_t embedding_idx = indices[idx];
+
+  // re-align the pointers
+  embedding_weights = &embedding_weights[embedding_idx * E];
+  out_embeddings = &out_embeddings[idx * E];
+
+  // copy the embedding out
+  for (unsigned i = threadIdx.x; i < E; i += THREADS_PER_BLOCK) {
+    out_embeddings[i] = embedding_weights[i];
+  }
+}
+
+void muillm_embedding_forward_xx16_indices_i32(
+  hipStream_t stream,
+  unsigned N,
+  unsigned E,
+  const uint16_t* weights,
+  const uint32_t* x,
+  uint16_t* out_embeddings,
+  int simd_lanes
+) {
+  const unsigned threads_per_blocks = THREADS_PER_BLOCK;
+
+  // TODO: max cuda grid dimension is 65k, so need to do something when N>65k
+  const unsigned num_blocks = N;
+
+  embedding_forward_xx16_indices_i32_kernel<<<num_blocks, threads_per_blocks, 0, stream>>>(
+    weights,
+    x,
+    out_embeddings,
+    E
+  );
+}
+
+
+// expected block dimensions: [x=N]
+__global__ void embedding_forward_xx16_indices_i64_kernel(
+  // inputs
+  const uint16_t* embedding_weights,
+  const uint64_t* indices,
+  // outputs
+  uint16_t* out_embeddings,
+  // other arguments
+  unsigned E
+) {
+  // one block copies one embedding
+  unsigned idx = blockIdx.x;
+
+  uint64_t embedding_idx = indices[idx];
+
+  // re-align the pointers
+  embedding_weights = &embedding_weights[embedding_idx * E];
+  out_embeddings = &out_embeddings[idx * E];
+
+  // copy the embedding out
+  for (unsigned i = threadIdx.x; i < E; i += THREADS_PER_BLOCK) {
+    out_embeddings[i] = embedding_weights[i];
+  }
+}
+
+void muillm_embedding_forward_xx16_indices_i64(
+  hipStream_t stream,
+  unsigned N,
+  unsigned E,
+  const uint16_t* weights,
+  const uint64_t* x,
+  uint16_t* out_embeddings,
+  int simd_lanes
+) {
+  const unsigned threads_per_blocks = THREADS_PER_BLOCK;
+
+  // TODO: max cuda grid dimension is 65k, so need to do something when N>65k
+  const unsigned num_blocks = N;
+
+  embedding_forward_xx16_indices_i64_kernel<<<num_blocks, threads_per_blocks, 0, stream>>>(
+    weights,
+    x,
+    out_embeddings,
+    E
+  );
+}

--- a/csrc/generation/generation.cu
+++ b/csrc/generation/generation.cu
@@ -1,0 +1,215 @@
+#include "generation.cuh"
+
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cstdint>
+
+#define DIV_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
+
+#define THREADS_PER_BLOCK 256
+
+// kernel to copy the previous tokens in the new array
+__global__ void muillm_copy_prev_tokens_kernel(
+  // inputs
+  const uint64_t* input_ids,
+  // outputs
+  uint64_t* next_input_ids, // size [B, T+1]
+  // other arguments
+  int T
+) {
+  unsigned batch_idx = blockIdx.y;
+  unsigned tok_idx = blockIdx.x * THREADS_PER_BLOCK + threadIdx.x;
+
+  if (tok_idx < T) {
+    next_input_ids[batch_idx * (T + 1) + tok_idx] = input_ids[batch_idx * T + tok_idx];
+  }
+}
+
+// kernel to copy the next tokens and check if the sequences
+// are finished or not
+__global__ void muillm_add_tokens_check_finished_kernel(
+    // inputs
+    const uint32_t* next_tokens,
+    const uint64_t* unfinished_sequences,
+    const uint64_t* eos_token_ids,
+    // outputs
+    uint64_t* next_input_ids, // size [B, T+1]
+    uint64_t* next_unfinished_sequences,
+    // other arguments
+    int64_t max_length,
+    int pad_token_id,
+    int B,
+    int T,
+    int NUM_EOS_TOKENS,
+    bool has_max_length_stopping_criteria,
+    bool has_eos_stopping_criteria
+) {
+  // each threads processes one batch entry
+  unsigned batch_idx = blockIdx.x * THREADS_PER_BLOCK + threadIdx.x;
+
+  if (batch_idx >= B) {
+    // out of bounds -> exit
+    return;
+  }
+
+  uint64_t next_token = next_tokens[batch_idx];
+
+  bool prev_unfinished = unfinished_sequences[batch_idx];
+
+  // first update the next_input_ids (so that we insert EOS tokens)
+  if (has_eos_stopping_criteria) {
+    // if the sequence was previously unfinished will copy out the next token
+    // (potentially it is eos_token_id and will finished the sequence though)
+    next_token = prev_unfinished ? next_token : pad_token_id;
+  }
+
+  next_input_ids[batch_idx] = next_token;
+
+  // copy out the next token
+  next_input_ids[batch_idx * (T + 1) + T] = next_token;
+
+  // then update the unfinished_sequences mask
+  bool unfinished = prev_unfinished;
+  if (has_max_length_stopping_criteria) {
+    unfinished = unfinished & (T <= max_length);
+  }
+
+  if (has_eos_stopping_criteria) {
+    if (NUM_EOS_TOKENS == 1) {
+      unfinished = unfinished & (next_token != eos_token_ids[0]);
+    } else if (NUM_EOS_TOKENS == 2) {
+      // if there are two eos tokens, we check if the next token is one of them
+      bool has_eos_tok0 = (next_token == eos_token_ids[0]);
+      bool has_eos_tok1 = (next_token == eos_token_ids[1]);
+      unfinished = unfinished & (!has_eos_tok0 && !has_eos_tok1);
+    } else if (NUM_EOS_TOKENS == 3) {
+      // if there are three eos tokens, we check if the next token is one of them
+      bool has_eos_tok0 = (next_token == eos_token_ids[0]);
+      bool has_eos_tok1 = (next_token == eos_token_ids[1]);
+      bool has_eos_tok2 = (next_token == eos_token_ids[2]);
+      unfinished = unfinished & (!has_eos_tok0 && !has_eos_tok1 && !has_eos_tok2);
+    } else if (NUM_EOS_TOKENS == 4) {
+      // if there are four eos tokens, we check if the next token is one of them
+      bool has_eos_tok0 = (next_token == eos_token_ids[0]);
+      bool has_eos_tok1 = (next_token == eos_token_ids[1]);
+      bool has_eos_tok2 = (next_token == eos_token_ids[2]);
+      bool has_eos_tok3 = (next_token == eos_token_ids[3]);
+      unfinished = unfinished & (!has_eos_tok0 && !has_eos_tok1 && !has_eos_tok2 && !has_eos_tok3);
+    } else {
+      // if there are more than four eos tokens, we check if the next token is one of them
+      // this is a bit inefficient, but it is not expected to be used often
+      bool is_eos_token = false;
+      for (int i = 0; i < NUM_EOS_TOKENS; ++i) {
+        if (next_token == eos_token_ids[i]) {
+          is_eos_token = true;
+          break;
+        }
+      }
+        unfinished = unfinished & !is_eos_token;
+    }
+  }
+
+  next_unfinished_sequences[batch_idx] = unfinished;
+}
+
+#define CHECK_CUDA(x) TORCH_CHECK(x.device().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
+
+std::tuple<torch::Tensor, torch::Tensor> muillm_add_tokens_check_finished(
+    torch::Tensor input_ids,
+    torch::Tensor next_tokens,
+    torch::Tensor unfinished_sequences,
+    bool has_eos_stopping_criteria,
+    int pad_token_id,
+    torch::Tensor eos_token_ids,
+    bool has_max_length_stopping_criteria,
+    int max_length
+) {
+  CHECK_INPUT(input_ids);
+  CHECK_INPUT(next_tokens);
+  CHECK_INPUT(unfinished_sequences);
+
+  auto device = input_ids.device();
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream(device.index());
+
+  const auto B = input_ids.size(0);
+  const auto T = input_ids.size(1);
+  const auto NUM_EOS_TOKENS = eos_token_ids.size(0);
+
+  if (unfinished_sequences.size(0) != B) {
+    TORCH_CHECK(false, "unfinished_sequences doesn't have the shape [B]");
+  }
+
+  auto input_ids_dtype = input_ids.dtype();
+
+  if (input_ids_dtype != torch::kInt64) {
+    TORCH_CHECK(false, "input_ids must be of type int64");
+  }
+
+  auto output_options = at::TensorOptions()
+                            .dtype(input_ids_dtype)
+                            .layout(at::kStrided)
+                            .device(device) // same output device as inputs
+                            .requires_grad(false);
+
+  auto next_input_ids = torch::empty({B, T + 1}, output_options);
+
+  auto unfinished_sequences_dtype = unfinished_sequences.dtype();
+
+  if (unfinished_sequences_dtype != torch::kInt64) {
+    TORCH_CHECK(false, "unfinished_sequences must be of type int64");
+  }
+
+  auto unfinished_output_options = at::TensorOptions()
+                            .dtype(unfinished_sequences_dtype)
+                            .layout(at::kStrided)
+                            .device(device) // same output device as inputs
+                            .requires_grad(false);
+
+  auto next_unfinished_sequences = torch::empty_like(unfinished_sequences, unfinished_output_options);
+
+  auto next_tokens_dtype = next_tokens.dtype();
+  if (next_tokens_dtype != torch::kInt) {
+    TORCH_CHECK(false, "next_tokens must be of type int");
+  }
+
+  { // call the cuda kernel to copy the previous tokens in the new array
+    const int threads_per_block = THREADS_PER_BLOCK;
+    const int num_blocks_x = DIV_ROUND_UP(T, threads_per_block);
+    const int num_blocks_y = B;
+
+    muillm_copy_prev_tokens_kernel<<<dim3(num_blocks_x, num_blocks_y), threads_per_block, 0, stream>>>(
+        // input pointers
+        (const uint64_t*) input_ids.data_ptr(),
+        // output pointers
+        (uint64_t*) next_input_ids.data_ptr(),
+        // other args
+        T
+    );
+  }
+  { // call the cuda kernel to copy the next tokens and check if the sequences are finished
+    const int threads_per_block = THREADS_PER_BLOCK;
+    const int num_blocks = DIV_ROUND_UP(B, threads_per_block);
+
+    muillm_add_tokens_check_finished_kernel<<<num_blocks, threads_per_block, 0, stream>>>(
+        // input pointers
+        (const uint32_t*) next_tokens.data_ptr(),
+        (const uint64_t*) unfinished_sequences.data_ptr(),
+        (const uint64_t*) eos_token_ids.data_ptr(),
+        // output pointers
+        (uint64_t*) next_input_ids.data_ptr(),
+        (uint64_t*) next_unfinished_sequences.data_ptr(),
+        // other args
+        max_length,
+        pad_token_id,
+        B,
+        T,
+        NUM_EOS_TOKENS,
+        has_eos_stopping_criteria,
+        has_max_length_stopping_criteria
+    );
+  }
+
+  return std::make_tuple(next_input_ids, next_unfinished_sequences);
+}

--- a/csrc/generation/generation.cuh
+++ b/csrc/generation/generation.cuh
@@ -1,0 +1,20 @@
+#ifndef __MUILLM_GENERATION_KERNELS_H__
+#define __MUILLM_GENERATION_KERNELS_H__
+
+#include <torch/extension.h>
+
+#include <tuple>
+
+// returns unfinished_sequences and input_ids
+std::tuple<torch::Tensor, torch::Tensor> muillm_add_tokens_check_finished(
+    torch::Tensor input_ids,
+    torch::Tensor next_tokens,
+    torch::Tensor unfinished_sequences,
+    bool has_eos_stopping_criteria,
+    int pad_token_id,
+    torch::Tensor eos_token_ids,
+    bool has_max_length_stopping_criteria,
+    int max_length
+);
+
+#endif /* __MUILLM_GENERATION_KERNELS_H__ */

--- a/csrc/module.cpp
+++ b/csrc/module.cpp
@@ -409,9 +409,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   pybind11::class_<muillm_parallel_decoder_stack_ptr_t> cl_parallel_decoder_stack(m, "muillm_parallel_decoder_stack_ptr");
   cl_parallel_decoder_stack.def(pybind11::init<>());
 
-  m.def("muillm_parallel_decoder_stack_init", &muillm_parallel_decoder_stack_init_trampoline, "muillm parallel decoder stack init", py::arg("engine"), py::arg("comm"), py::arg("decoders"));
+  m.def("muillm_parallel_decoder_stack_init", &muillm_parallel_decoder_stack_init_trampoline, "muillm parallel decoder stack init", py::arg("engine"), py::arg("comm"), py::arg("rotary_emb_module"), py::arg("decoders"));
   m.def("muillm_parallel_decoder_stack_deinit", &muillm_parallel_decoder_stack_deinit_trampoline, "muillm parallel decoder stack deinit", py::arg("module"));
-  m.def("muillm_parallel_decoder_stack_forward", &muillm_parallel_decoder_stack_forward_trampoline, "muillm parallel decoder stack forward", py::arg("module"), py::arg("cache"), py::arg("h"), py::arg("m"), py::arg("position_ids"), py::arg("cos_sin"), py::arg("cache_positions"));
+  m.def("muillm_parallel_decoder_stack_forward", &muillm_parallel_decoder_stack_forward_trampoline, "muillm parallel decoder stack forward", py::arg("module"), py::arg("cache"), py::arg("h"), py::arg("m"), py::arg("position_ids"), py::arg("cache_positions"));
 
   // parallel llama4 decoder stack
   pybind11::class_<muillm_parallel_llama4_decoder_stack_ptr_t> cl_parallel_llama4_decoder_stack(m, "muillm_parallel_llama4_decoder_stack_ptr");

--- a/csrc/module.cpp
+++ b/csrc/module.cpp
@@ -149,6 +149,7 @@ at::Tensor muillm_to_cpu_trampoline(
 #include "comm_torch.h"
 
 #include "modules/linear_module.h"
+#include "modules/embedding_module.h"
 
 #include "parallel_linear_kernels.cuh"
 #include "parallel_gateupmoe_kernels.cuh"
@@ -310,6 +311,14 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("muillm_linear_module_deinit", &muillm_linear_module_deinit_trampoline, "muillm linear module deinit", py::arg("module"));
   m.def("muillm_linear_module_forward", &muillm_linear_module_forward_trampoline, "muillm linear module forward", py::arg("module"), py::arg("inputs"), py::arg("residual") = py::none());
 
+  // embedding
+  pybind11::class_<muillm_embedding_module_ptr_t> cl_embedding_module(m, "muillm_embedding_module_ptr");
+  cl_embedding_module.def(pybind11::init<>());
+
+  m.def("muillm_embedding_module_init", &muillm_embedding_module_init_trampoline, "muillm embedding module init", py::arg("engine"), py::arg("weights"));
+  m.def("muillm_embedding_module_deinit", &muillm_embedding_module_deinit_trampoline, "muillm embedding module deinit", py::arg("module"));
+  m.def("muillm_embedding_module_forward", &muillm_embedding_module_forward_trampoline, "muillm embedding module forward", py::arg("module"), py::arg("inputs"));
+
 
   // parallel linear
   pybind11::class_<muillm_parallel_linear_module_ptr_t> cl_parallel_linear_module(m, "muillm_parallel_linear_module_ptr");
@@ -409,9 +418,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   pybind11::class_<muillm_parallel_decoder_stack_ptr_t> cl_parallel_decoder_stack(m, "muillm_parallel_decoder_stack_ptr");
   cl_parallel_decoder_stack.def(pybind11::init<>());
 
-  m.def("muillm_parallel_decoder_stack_init", &muillm_parallel_decoder_stack_init_trampoline, "muillm parallel decoder stack init", py::arg("engine"), py::arg("comm"), py::arg("rotary_emb_module"), py::arg("decoders"));
+  m.def("muillm_parallel_decoder_stack_init", &muillm_parallel_decoder_stack_init_trampoline, "muillm parallel decoder stack init", py::arg("engine"), py::arg("comm"), py::arg("embed_tokens_module"), py::arg("rotary_emb_module"), py::arg("decoders"));
   m.def("muillm_parallel_decoder_stack_deinit", &muillm_parallel_decoder_stack_deinit_trampoline, "muillm parallel decoder stack deinit", py::arg("module"));
-  m.def("muillm_parallel_decoder_stack_forward", &muillm_parallel_decoder_stack_forward_trampoline, "muillm parallel decoder stack forward", py::arg("module"), py::arg("cache"), py::arg("h"), py::arg("m"), py::arg("position_ids"), py::arg("cache_positions"));
+  m.def("muillm_parallel_decoder_stack_forward", &muillm_parallel_decoder_stack_forward_trampoline, "muillm parallel decoder stack forward", py::arg("module"), py::arg("cache"), py::arg("input_ids"), py::arg("input_embeds"), py::arg("m"), py::arg("position_ids"), py::arg("cache_positions"));
 
   // parallel llama4 decoder stack
   pybind11::class_<muillm_parallel_llama4_decoder_stack_ptr_t> cl_parallel_llama4_decoder_stack(m, "muillm_parallel_llama4_decoder_stack_ptr");

--- a/csrc/modules/embedding_module.cpp
+++ b/csrc/modules/embedding_module.cpp
@@ -1,0 +1,80 @@
+#include "embedding_module.h"
+
+#include "../embedding/embedding.cuh"
+
+//
+// actual module
+//
+
+MuiLLMEmbedding::MuiLLMEmbedding(
+  muillm_engine_t* engine,
+  torch::Tensor& weights
+) {
+  this->engine = engine;
+
+  // we don't register as parameter in case it duplicates the memory
+  this->weights = weights;
+
+  auto wdtype = weights.dtype();
+  bool dispatchable_type = (wdtype == torch::kFloat16) || (wdtype == torch::kBFloat16);
+  bool dispatchable_device = weights.device().is_cuda();
+  this->dispatchable = dispatchable_type && dispatchable_device;
+}
+
+MuiLLMEmbedding::~MuiLLMEmbedding() {
+  // nothing to do
+}
+
+torch::Tensor MuiLLMEmbedding::forward(
+    torch::Tensor& inputs
+) {
+  if (this->dispatchable) {
+    return muillm_embedding_forward(
+      this->engine,
+      this->weights,
+      inputs
+    );
+  } else {
+    // embedding
+    auto output = torch::nn::functional::embedding(inputs, this->weights);
+    return output;
+  }
+}
+
+//
+// Python trampolines
+//
+
+// init
+muillm_embedding_module_ptr_t muillm_embedding_module_init_trampoline(
+  muillm_engine_ptr engine,
+  torch::Tensor weights
+) {
+
+  MuiLLMEmbedding* m = new MuiLLMEmbedding(
+    engine.engine_ptr,
+    weights
+  );
+
+  muillm_embedding_module_ptr_t ret;
+  ret.ptr = m;
+  return ret;
+}
+
+// deinit
+void muillm_embedding_module_deinit_trampoline(
+  muillm_embedding_module_ptr_t module_ptr
+) {
+  delete module_ptr.ptr;
+}
+
+// forward
+at::Tensor muillm_embedding_module_forward_trampoline(
+  muillm_embedding_module_ptr_t module_ptr,
+  torch::Tensor& inputs
+) {
+
+  MuiLLMEmbedding* m = module_ptr.ptr;
+
+  return m->forward(inputs);
+}

--- a/csrc/modules/embedding_module.h
+++ b/csrc/modules/embedding_module.h
@@ -1,0 +1,53 @@
+#ifndef __MUILLM_EMBEDDING_MODULE_H__
+#define __MUILLM_EMBEDDING_MODULE_H__
+
+#include "../engine.h"
+
+#include <optional>
+
+#include <torch/torch.h>
+
+struct MuiLLMEmbedding: torch::nn::Module {
+  // fields
+  muillm_engine_t* engine;
+  
+  torch::Tensor weights{nullptr};
+
+  bool dispatchable;
+
+  // methods
+  MuiLLMEmbedding(
+    muillm_engine_t* engine,
+    torch::Tensor& weights
+  );
+
+  virtual ~MuiLLMEmbedding();
+
+  torch::Tensor forward(
+    torch::Tensor& inputs
+  );
+};
+
+// needed because Pybind11 can't seem to be able to deal with opaque pointers
+typedef struct muillm_embedding_module_ptr {
+  MuiLLMEmbedding* ptr;
+} muillm_embedding_module_ptr_t;
+
+// init
+muillm_embedding_module_ptr_t muillm_embedding_module_init_trampoline(
+  muillm_engine_ptr engine,
+  torch::Tensor weights
+);
+
+// deinit
+void muillm_embedding_module_deinit_trampoline(
+  muillm_embedding_module_ptr_t module_ptr
+);
+
+// forward
+at::Tensor muillm_embedding_module_forward_trampoline(
+  muillm_embedding_module_ptr_t module_ptr,
+  torch::Tensor& inputs
+);
+
+#endif /* __MUILLM_EMBEDDING_MODULE_H__ */

--- a/csrc/modules/linear_module.h
+++ b/csrc/modules/linear_module.h
@@ -2,7 +2,6 @@
 #define __MUILLM_LINEAR_MODULE_H__
 
 #include "../engine.h"
-#include "../comm_torch.h"
 
 #include <optional>
 

--- a/csrc/modules/parallel_decoder_stack.cpp
+++ b/csrc/modules/parallel_decoder_stack.cpp
@@ -3,11 +3,13 @@
 MuiLLMParallelDecoderStack::MuiLLMParallelDecoderStack(
   muillm_engine_t* engine,
   muillm_comm_t* comm,
+  MuillmRotaryEmbedding* rotary_embedding,
   std::vector<MuiLLMParallelDecoder*>& decoders
 ) {
   this->engine = engine;
   this->comm = comm;
 
+  this->rotary_embedding = rotary_embedding;
   this->decoders = decoders;
 }
 
@@ -20,10 +22,13 @@ torch::Tensor MuiLLMParallelDecoderStack::forward(
   torch::Tensor& h,
   torch::Tensor& m,
   torch::Tensor& position_ids,
-  std::optional<std::tuple<torch::Tensor, torch::Tensor>>& cos_sin,
   torch::Tensor& cache_positions
 ) {
   torch::Tensor h_ = h;
+
+  std::optional<std::tuple<torch::Tensor, torch::Tensor>> cos_sin = this->rotary_embedding != nullptr ?
+      std::make_optional<std::tuple<torch::Tensor, torch::Tensor>>(rotary_embedding->compute_rotary_pos_emb(h, position_ids))
+      : std::optional<std::tuple<torch::Tensor, torch::Tensor>>();
 
   for (auto decoder: this->decoders) {
     h_ = decoder->forward(cache, h_, m, position_ids, cos_sin, cache_positions);
@@ -35,6 +40,7 @@ torch::Tensor MuiLLMParallelDecoderStack::forward(
 muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampoline(
   muillm_engine_ptr engine,
   muillm_comm_ptr comm,
+  muillm_rotary_embedding_module_ptr_t& rotary_embedding_module,
   std::vector<muillm_parallel_decoder_module_ptr_t>& decoders
 ) {
   std::vector<MuiLLMParallelDecoder*> decoders_;
@@ -45,6 +51,7 @@ muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampolin
   MuiLLMParallelDecoderStack* decoder_stack = new MuiLLMParallelDecoderStack(
     engine.engine_ptr,
     comm.comm_ptr,
+    rotary_embedding_module.ptr,
     decoders_
   );
 
@@ -65,11 +72,10 @@ torch::Tensor muillm_parallel_decoder_stack_forward_trampoline(
   torch::Tensor& h,
   std::optional<torch::Tensor>& m_,
   torch::Tensor& position_ids,
-  std::optional<std::tuple<torch::Tensor, torch::Tensor>>& cos_sin,
   torch::Tensor& cache_positions
 ) {
   auto undef_tensor = torch::Tensor();
   auto m = m_.has_value() ? m_.value() : undef_tensor;
 
-  return module_ptr.ptr->forward(cache_ptr.ptr, h, m, position_ids, cos_sin, cache_positions);
+  return module_ptr.ptr->forward(cache_ptr.ptr, h, m, position_ids, cache_positions);
 }

--- a/csrc/modules/parallel_decoder_stack.cpp
+++ b/csrc/modules/parallel_decoder_stack.cpp
@@ -3,12 +3,14 @@
 MuiLLMParallelDecoderStack::MuiLLMParallelDecoderStack(
   muillm_engine_t* engine,
   muillm_comm_t* comm,
+  MuiLLMEmbedding* embed_tokens,
   MuillmRotaryEmbedding* rotary_embedding,
   std::vector<MuiLLMParallelDecoder*>& decoders
 ) {
   this->engine = engine;
   this->comm = comm;
 
+  this->embed_tokens = embed_tokens;
   this->rotary_embedding = rotary_embedding;
   this->decoders = decoders;
 }
@@ -19,16 +21,21 @@ MuiLLMParallelDecoderStack::~MuiLLMParallelDecoderStack() {
 
 torch::Tensor MuiLLMParallelDecoderStack::forward(
   MuillmKVCache* cache,
-  torch::Tensor& h,
+  torch::Tensor& input_ids,
+  torch::Tensor& input_embeds,
   torch::Tensor& m,
   torch::Tensor& position_ids,
   torch::Tensor& cache_positions
 ) {
-  torch::Tensor h_ = h;
+  // compute the input embeddings if not provided
+  bool inputs_defined = input_embeds.defined();
+  torch::Tensor h = inputs_defined ? input_embeds : this->embed_tokens->forward(input_ids);
 
   std::optional<std::tuple<torch::Tensor, torch::Tensor>> cos_sin = this->rotary_embedding != nullptr ?
       std::make_optional<std::tuple<torch::Tensor, torch::Tensor>>(rotary_embedding->compute_rotary_pos_emb(h, position_ids))
       : std::optional<std::tuple<torch::Tensor, torch::Tensor>>();
+
+  torch::Tensor h_ = h;
 
   for (auto decoder: this->decoders) {
     h_ = decoder->forward(cache, h_, m, position_ids, cos_sin, cache_positions);
@@ -40,6 +47,7 @@ torch::Tensor MuiLLMParallelDecoderStack::forward(
 muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampoline(
   muillm_engine_ptr engine,
   muillm_comm_ptr comm,
+  muillm_embedding_module_ptr_t& embed_tokens,
   muillm_rotary_embedding_module_ptr_t& rotary_embedding_module,
   std::vector<muillm_parallel_decoder_module_ptr_t>& decoders
 ) {
@@ -51,6 +59,7 @@ muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampolin
   MuiLLMParallelDecoderStack* decoder_stack = new MuiLLMParallelDecoderStack(
     engine.engine_ptr,
     comm.comm_ptr,
+    embed_tokens.ptr,
     rotary_embedding_module.ptr,
     decoders_
   );
@@ -69,13 +78,15 @@ void muillm_parallel_decoder_stack_deinit_trampoline(
 torch::Tensor muillm_parallel_decoder_stack_forward_trampoline(
   muillm_parallel_decoder_stack_ptr_t module_ptr,
   muillm_kvcache_module_ptr_t cache_ptr,
-  torch::Tensor& h,
+  torch::Tensor& input_ids,
+  std::optional<torch::Tensor>& input_embeds_,
   std::optional<torch::Tensor>& m_,
   torch::Tensor& position_ids,
   torch::Tensor& cache_positions
 ) {
   auto undef_tensor = torch::Tensor();
+  auto input_embeds = input_embeds_.has_value() ? input_embeds_.value() : undef_tensor;
   auto m = m_.has_value() ? m_.value() : undef_tensor;
 
-  return module_ptr.ptr->forward(cache_ptr.ptr, h, m, position_ids, cache_positions);
+  return module_ptr.ptr->forward(cache_ptr.ptr, input_ids, input_embeds, m, position_ids, cache_positions);
 }

--- a/csrc/modules/parallel_decoder_stack.h
+++ b/csrc/modules/parallel_decoder_stack.h
@@ -6,6 +6,7 @@
 
 #include "parallel_decoder_module.h"
 #include "kvcache.h"
+#include "embedding_module.h"
 #include "rotary_module.h"
 
 #include <vector>
@@ -16,6 +17,7 @@ struct MuiLLMParallelDecoderStack: torch::nn::Module {
   muillm_engine_t* engine;
   muillm_comm_t* comm;
 
+  MuiLLMEmbedding* embed_tokens;
   MuillmRotaryEmbedding* rotary_embedding;
   std::vector<MuiLLMParallelDecoder*> decoders;
 
@@ -23,6 +25,7 @@ struct MuiLLMParallelDecoderStack: torch::nn::Module {
   MuiLLMParallelDecoderStack(
     muillm_engine_t* engine,
     muillm_comm_t* comm,
+    MuiLLMEmbedding* embed_tokens,
     MuillmRotaryEmbedding* rotary_embedding,
     std::vector<MuiLLMParallelDecoder*>& decoders
   );
@@ -31,7 +34,8 @@ struct MuiLLMParallelDecoderStack: torch::nn::Module {
 
   torch::Tensor forward(
     MuillmKVCache* cache,
-    torch::Tensor& h,
+    torch::Tensor& input_ids,
+    torch::Tensor& input_embeds,
     torch::Tensor& m,
     torch::Tensor& position_ids,
     torch::Tensor& cache_positions
@@ -46,6 +50,7 @@ typedef struct muillm_parallel_decoder_stack_ptr {
 muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampoline(
   muillm_engine_ptr engine,
   muillm_comm_ptr comm,
+  muillm_embedding_module_ptr_t& embed_tokens,
   muillm_rotary_embedding_module_ptr_t& rotary_embedding_module,
   std::vector<muillm_parallel_decoder_module_ptr_t>& decoders
 );
@@ -57,7 +62,8 @@ void muillm_parallel_decoder_stack_deinit_trampoline(
 torch::Tensor muillm_parallel_decoder_stack_forward_trampoline(
   muillm_parallel_decoder_stack_ptr_t module_ptr,
   muillm_kvcache_module_ptr_t cache_ptr,
-  torch::Tensor& h,
+  torch::Tensor& input_ids,
+  std::optional<torch::Tensor>& input_embeds,
   std::optional<torch::Tensor>& m,
   torch::Tensor& position_ids,
   torch::Tensor& cache_positions

--- a/csrc/modules/parallel_decoder_stack.h
+++ b/csrc/modules/parallel_decoder_stack.h
@@ -6,6 +6,7 @@
 
 #include "parallel_decoder_module.h"
 #include "kvcache.h"
+#include "rotary_module.h"
 
 #include <vector>
 #include <optional>
@@ -15,12 +16,14 @@ struct MuiLLMParallelDecoderStack: torch::nn::Module {
   muillm_engine_t* engine;
   muillm_comm_t* comm;
 
+  MuillmRotaryEmbedding* rotary_embedding;
   std::vector<MuiLLMParallelDecoder*> decoders;
 
   // methods
   MuiLLMParallelDecoderStack(
     muillm_engine_t* engine,
     muillm_comm_t* comm,
+    MuillmRotaryEmbedding* rotary_embedding,
     std::vector<MuiLLMParallelDecoder*>& decoders
   );
 
@@ -31,7 +34,6 @@ struct MuiLLMParallelDecoderStack: torch::nn::Module {
     torch::Tensor& h,
     torch::Tensor& m,
     torch::Tensor& position_ids,
-    std::optional<std::tuple<torch::Tensor, torch::Tensor>>& cos_sin,
     torch::Tensor& cache_positions
   );
 };
@@ -44,6 +46,7 @@ typedef struct muillm_parallel_decoder_stack_ptr {
 muillm_parallel_decoder_stack_ptr_t muillm_parallel_decoder_stack_init_trampoline(
   muillm_engine_ptr engine,
   muillm_comm_ptr comm,
+  muillm_rotary_embedding_module_ptr_t& rotary_embedding_module,
   std::vector<muillm_parallel_decoder_module_ptr_t>& decoders
 );
 
@@ -57,7 +60,6 @@ torch::Tensor muillm_parallel_decoder_stack_forward_trampoline(
   torch::Tensor& h,
   std::optional<torch::Tensor>& m,
   torch::Tensor& position_ids,
-  std::optional<std::tuple<torch::Tensor, torch::Tensor>>& cos_sin,
   torch::Tensor& cache_positions
 );
 

--- a/csrc/modules/rotary_module.cpp
+++ b/csrc/modules/rotary_module.cpp
@@ -128,7 +128,12 @@ std::tuple<torch::Tensor, torch::Tensor> MuillmRotaryEmbedding::compute_rotary_p
   torch::Tensor& x,
   torch::Tensor& position_ids
 ) {
-  TORCH_CHECK(false, "compute_rotary_pos_emb is not implemented");
+  return muillm_compute_rotary_embed_positions(
+    x,
+    position_ids, 
+    this->cos_cached,
+    this->sin_cached
+  );
 }
 
 muillm_rotary_embedding_module_ptr_t muillm_rotary_embedding_module_init_trampoline(

--- a/csrc/rope/rotary.h
+++ b/csrc/rope/rotary.h
@@ -7,6 +7,14 @@
 
 #include "rotary_position_layout.h"
 
+// out: cos, sin
+std::tuple<at::Tensor, at::Tensor> muillm_compute_rotary_embed_positions(
+    torch::Tensor& x,
+    torch::Tensor& position_ids, // shape [batch_size, seq_len]
+    torch::Tensor& cos_cached,
+    torch::Tensor& sin_cached
+);
+
 // out: query, key
 std::tuple<at::Tensor, at::Tensor> muillm_rope_forward_no_cache(
     torch::Tensor& position_ids,

--- a/muillm/modules/attention/rotaryembedding.py
+++ b/muillm/modules/attention/rotaryembedding.py
@@ -186,7 +186,8 @@ class MuiRotaryEmbedding(MuiModule):
         self.output_complex = output_complex
         self.layer_idx = layer_idx
 
-        dtype = dtype if dtype is not None else torch.get_default_dtype()
+        # default to use use float32 for cos/sin caches
+        dtype = dtype if dtype is not None else torch.float32
 
         if config is not None:
             if isinstance(config, LlamaConfig) or isinstance(config, MistralConfig):

--- a/muillm/modules/attention/sdpaattention.py
+++ b/muillm/modules/attention/sdpaattention.py
@@ -26,7 +26,7 @@ logger = logging.get_logger(__name__)
 # Modified to avoid a sync
 def _ignore_causal_mask_sdpa(
     attention_mask: Optional[torch.Tensor],
-    inputs_embeds: torch.Tensor,
+    inputs_shape: torch.Size,
     past_key_values_length: int,
     sliding_window: Optional[int] = None,
     all_ones_mask: Optional[bool] = None,
@@ -40,12 +40,12 @@ def _ignore_causal_mask_sdpa(
     allowing to dispatch to the flash attention kernel (that can otherwise not be used if a custom `attn_mask` is passed).
     """
 
-    _, query_length = inputs_embeds.shape[0], inputs_embeds.shape[1]
+    query_length = inputs_shape[1]
     key_value_length = query_length + past_key_values_length
 
     is_tracing = (
         torch.jit.is_tracing()
-        or isinstance(inputs_embeds, torch.fx.Proxy)
+        # or isinstance(inputs_embeds, torch.fx.Proxy)
         or (hasattr(torch, "_dynamo") and torch._dynamo.is_compiling())
     )
 

--- a/muillm/modules/attention/sdpaattention.py
+++ b/muillm/modules/attention/sdpaattention.py
@@ -57,6 +57,7 @@ def _ignore_causal_mask_sdpa(
         # Thus, we only set `ignore_causal_mask = True` if the model is set to training.
         #
         # Besides, jit.trace can not handle the `q_len > 1` condition for `is_causal` (`TypeError: scaled_dot_product_attention(): argument 'is_causal' must be bool, not Tensor`).
+        # if we are here, there is no padding being done otherwise we would have an attention_mask (e.g if batching irregular sequences).
         if (
             (is_training or not is_tracing)
             and (query_length == 1 or key_value_length == query_length)

--- a/muillm/modules/decoder/paralleldecoderstack.py
+++ b/muillm/modules/decoder/paralleldecoderstack.py
@@ -3,17 +3,17 @@ import muillm_ext
 import torch
 import torch.nn as nn
 
+
 class _MuiParallelDecoderStack(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, module, cache_module, h, m, position_ids, position_embeddings, cache_positions):
+    def forward(ctx, module, cache_module, h, m, position_ids, cache_positions):
         output = muillm_ext.muillm_parallel_decoder_stack_forward(
             module,
             cache_module,
             h,
             m,
             position_ids,
-            position_embeddings,
-            cache_positions
+            cache_positions,
         )
 
         ctx.save_for_backward(h, m)

--- a/muillm/modules/decoder/paralleldecoderstack.py
+++ b/muillm/modules/decoder/paralleldecoderstack.py
@@ -6,16 +6,24 @@ import torch.nn as nn
 
 class _MuiParallelDecoderStack(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, module, cache_module, h, m, position_ids, cache_positions):
+    def forward(
+        ctx,
+        module,
+        cache_module,
+        input_ids,
+        input_embeds,
+        m,
+        position_ids,
+        cache_positions,
+    ):
         output = muillm_ext.muillm_parallel_decoder_stack_forward(
             module,
             cache_module,
-            h,
+            input_ids,
+            input_embeds,
             m,
             position_ids,
             cache_positions,
         )
-
-        ctx.save_for_backward(h, m)
 
         return output

--- a/muillm/modules/embedding.py
+++ b/muillm/modules/embedding.py
@@ -1,0 +1,161 @@
+from typing import Optional, Union
+from muillm.engineconfig import MuiEngineConfig
+from muillm.memorymanagement.gc import trigger_gc
+from muillm.modules.module import MuiModule
+
+import torch
+import torch.nn as nn
+
+import muillm_ext
+from muillm.replacement.replacementcontext import MuiReplacementContext
+
+
+class _MuiEmbedding(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, module, x):
+        output = muillm_ext.muillm_embedding_module_forward(module, x)
+
+        ctx.save_for_backward(x)
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        raise NotImplementedError("embedding backward is not implemented")
+
+
+class MuiEmbedding(MuiModule, nn.Module):
+    def __init__(
+        self,
+        engine_config: MuiEngineConfig,
+        num_embeddings: int,
+        embedding_dim: int,
+        padding_idx: Optional[int] = None,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        sparse: bool = False,
+        device=None,
+        dtype=None,
+    ):
+        MuiModule.__init__(self, engine_config)
+        nn.Module.__init__(self)
+
+        self.cpp_engine = engine_config.cpp_engine
+
+        embeddings = nn.Embedding(
+            num_embeddings=num_embeddings,
+            embedding_dim=embedding_dim,
+            padding_idx=padding_idx,
+            max_norm=max_norm,
+            norm_type=norm_type,
+            scale_grad_by_freq=scale_grad_by_freq,
+            sparse=sparse,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.weight = embeddings.weight
+
+        # cache the flags checking if it is dispatchable
+        self._check_dispatchable()
+
+        # the cpp module will be created at the end of all layer replacements
+        self.cpp_module = None
+
+    def _check_dispatchable(self):
+        wdtype = self.weight.dtype
+        dispatchable_type = (wdtype == torch.float16) or (wdtype == torch.bfloat16)
+        dispatchable_device = self.weight.is_cuda
+        self.dispatchable = dispatchable_device and dispatchable_type
+
+    def finalize_init(self):
+        if self.cpp_module is not None:
+            muillm_ext.muillm_embedding_module_deinit(self.cpp_module)
+
+        self.cpp_module = muillm_ext.muillm_embedding_module_init(
+            self.cpp_engine,
+            self.weight,
+        )
+
+        # cache the flags checking if it is dispatchable
+        self._check_dispatchable()
+
+    @staticmethod
+    def replace(
+        replacement_context: MuiReplacementContext,
+        prev_module: Union["MuiEmbedding", nn.Embedding],
+    ) -> "MuiEmbedding":
+
+        engine_config = replacement_context.engine_config
+        device = replacement_context.device
+        if device is None:
+            raise ValueError("device was None")
+
+        if isinstance(prev_module, MuiEmbedding):
+            # re-creating a module would change nothing, we can just avoid id
+            return prev_module
+
+        # Make sure we convert the previous module to a local module
+        # so that we can safely copy its parameters
+        prev_module = replacement_context.to_local_module(prev_module)
+
+        device = prev_module.weight.device if device is None else device
+        dtype = prev_module.weight.dtype
+
+        # put on the end device to accelerate things
+        # (ok as we are replacing the module entirely so we can change its device)
+        if device is not None:
+            prev_module = prev_module.to(device)
+
+        new_module = MuiEmbedding(
+            engine_config=engine_config,
+            num_embeddings=prev_module.num_embeddings,
+            embedding_dim=prev_module.embedding_dim,
+            padding_idx=prev_module.padding_idx,
+            max_norm=prev_module.max_norm,
+            norm_type=prev_module.norm_type,
+            scale_grad_by_freq=prev_module.scale_grad_by_freq,
+            sparse=prev_module.sparse,
+            device=device,
+            dtype=dtype,
+        )
+
+        new_module.copy_module(prev_module, device=device)
+
+        # delete the previous modules to free memory
+        del prev_module.weight
+
+        # trigger garbage collection to free memory
+        trigger_gc()
+
+        return new_module
+
+    def copy_module(
+        self,
+        prev_module: nn.Embedding,
+        device=None,
+    ):
+        if device is None:
+            raise ValueError("device was None")
+
+        requires_grads = prev_module.weight.requires_grad
+        self.weight.data.copy_(prev_module.weight.data)
+        self.weight.requires_grad = requires_grads
+
+        # put ourselves on the right device
+        self.to(device=device)
+
+        # cache the flags checking if it is dispatchable
+        self._check_dispatchable()
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if self.cpp_module is not None:
+            return _MuiEmbedding.apply(
+                self.cpp_module,
+                input,
+            )
+
+        # TODO: to support training we would have to pass all the other parameters
+        # (padding_idx, max norm etc)
+        return torch.nn.functional.embedding(input, self.weight)

--- a/muillm/modules/models/llama/model.py
+++ b/muillm/modules/models/llama/model.py
@@ -790,25 +790,43 @@ class MuiLlamaForCausalLM(LlamaPreTrainedModel, MuiGenerationMixin):
         position_ids=None,
         use_cache=True,
         num_logits_to_keep=None,
+        next_tokens=None,
+        prev_position_ids=None,
         **kwargs,
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
         # Exception 1: when passing input_embeds, input_ids may be missing entries
         # Exception 2: some generation methods do special slicing of input_ids, so we don't need to do it here
         if past_key_values is not None:
-            if inputs_embeds is not None:  # Exception 1
+            if next_tokens is not None:
+                # previously computed next tokens are the tokens to process now
+                # next_tokens has shape [batch_size], but we need [batch_size, 1]
+                input_ids = next_tokens.unsqueeze(1)
+            elif inputs_embeds is not None:  # Exception 1
                 input_ids = input_ids[:, -cache_position.shape[0] :]
             elif (
                 input_ids.shape[1] != cache_position.shape[0]
             ):  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
-        if attention_mask is not None and position_ids is None:
-            # create position_ids on the fly for batch generation
-            position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 1)
+        if (attention_mask is not None) and (position_ids is None):
+            if prev_position_ids is None:
+                # No previous position_ids, so we create them from the attention mask
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+            else:
+                # just increment the previous position ids
+                position_ids = prev_position_ids + 1
+
             if past_key_values:
-                position_ids = position_ids[:, -input_ids.shape[1] :]
+                if position_ids.shape[1] != input_ids.shape[1]:
+                    # if we are doing the first decode, prev_position_ids
+                    # contain several tokens but need a single one
+                    position_ids = position_ids[:, -input_ids.shape[1] :]
+
+            # if self.engine_config.is_rank0():
+            #     print(f"(prepare inputs) position_ids shape: ", position_ids.shape)
+            #     print(f"(prepare inputs) position_ids: ", position_ids)
 
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and cache_position[0] == 0:

--- a/muillm/modules/models/mistral/model.py
+++ b/muillm/modules/models/mistral/model.py
@@ -809,25 +809,39 @@ class MuiMistralForCausalLM(MistralPreTrainedModel, MuiGenerationMixin):
         position_ids=None,
         use_cache=True,
         num_logits_to_keep=None,
+        next_tokens=None,
+        prev_position_ids=None,
         **kwargs
     ):
         # If we have cache: let's slice `input_ids` through `cache_position`, to keep only the unprocessed tokens
         # Exception 1: when passing input_embeds, input_ids may be missing entries
         # Exception 2: some generation methods do special slicing of input_ids, so we don't need to do it here
         if past_key_values is not None:
-            if inputs_embeds is not None:  # Exception 1
+            if next_tokens is not None:
+                # previously computed next tokens are the tokens to process now
+                # next_tokens has shape [batch_size], but we need [batch_size, 1]
+                input_ids = next_tokens.unsqueeze(1)
+            elif inputs_embeds is not None:  # Exception 1
                 input_ids = input_ids[:, -cache_position.shape[0] :]
             elif (
                 input_ids.shape[1] != cache_position.shape[0]
             ):  # Default case (the "else", a no op, is Exception 2)
                 input_ids = input_ids[:, cache_position]
 
-        if attention_mask is not None and position_ids is None:
-            # create position_ids on the fly for batch generation
-            position_ids = attention_mask.long().cumsum(-1) - 1
-            position_ids.masked_fill_(attention_mask == 0, 1)
+        if (attention_mask is not None) and (position_ids is None):
+            if prev_position_ids is None:
+                # No previous position_ids, so we create them from the attention mask
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+            else:
+                # just increment the previous position ids
+                position_ids = prev_position_ids + 1
+
             if past_key_values:
-                position_ids = position_ids[:, -input_ids.shape[1] :]
+                if position_ids.shape[1] != input_ids.shape[1]:
+                    # if we are doing the first decode, prev_position_ids
+                    # contain several tokens but need a single one
+                    position_ids = position_ids[:, -input_ids.shape[1] :]
 
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step
         if inputs_embeds is not None and cache_position[0] == 0:

--- a/muillm/replacement/replacements.py
+++ b/muillm/replacement/replacements.py
@@ -4,6 +4,7 @@ from muillm.modules.decoder.paralleldecoder import MuiParallelDecoderLayer
 from muillm.modules.decoder.parallelllama4decoder import (
     MuiParallelLlama4TextDecoderLayer,
 )
+from muillm.modules.embedding import MuiEmbedding
 from muillm.modules.norm.l2norm import MuiL2Norm
 from muillm.modules.models.llama.model import MuiLlamaForCausalLM, MuiLlamaModel
 from muillm.modules.models.llama4.model import (
@@ -63,6 +64,8 @@ from muillm.replacement.replacementcontext import (
 
 
 _LAYER_REPLACEMENTS = {
+    # Embeddings
+    nn.Embedding: MuiEmbedding,
     # Linear
     nn.Linear: MuiLinear,
     # MLPs
@@ -96,6 +99,8 @@ _LAYER_REPLACEMENTS = {
 }
 
 _TP_LAYER_REPLACEMENTS = {
+    # Embeddings
+    nn.Embedding: MuiEmbedding,
     # Linear
     MuiMultiLinear: MuiParallelMultiLinear,
     nn.Linear: MuiParallelLinear,

--- a/muillm/sampling/generation.py
+++ b/muillm/sampling/generation.py
@@ -258,6 +258,13 @@ class MuiGenerationMixin(MuiModule, GenerationMixin):
                     # used to avoid some checks when updating masks later on
                     # as we generate we just add more ones, so the flag won't change
                     self.all_ones_mask = torch.all(attention_mask == 1).item()
+                else:
+                    # No attention mask mean all ones as well
+                    self.all_ones_mask = True
+
+            if self.all_ones_mask is not None:
+                # Add the all_ones_mask as input
+                model_inputs["all_ones_mask"] = self.all_ones_mask
 
             # prepare variable output controls (note: some models won't accept all output controls)
             model_inputs.update(

--- a/muillm/sampling/generation.py
+++ b/muillm/sampling/generation.py
@@ -27,7 +27,46 @@ from muillm.sampling.multinomial import muillm_multinomial_sample_one_no_sync
 
 
 from transformers.generation import GenerationMixin
+from transformers.generation.stopping_criteria import (
+    EosTokenCriteria,
+    MaxLengthCriteria,
+)
+
 from transformers.cache_utils import Cache
+
+
+import muillm_ext
+
+
+class _MuiAddTokensCheckFinished(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input_ids: torch.LongTensor,  # shape [batch_size, sequence_length]
+        next_tokens: torch.LongTensor,  # shape [batch_size]
+        unfinished_sequences: torch.LongTensor,  # shape [batch_size]
+        has_eos_stopping_criteria: bool,
+        pad_token_id: int,
+        eos_token_id: int,
+        has_max_length_stopping_criteria: bool,
+        max_length: Optional[int],
+    ) -> Tuple[torch.BoolTensor, torch.LongTensor]:
+        output = muillm_ext.muillm_add_tokens_check_finished(
+            input_ids,
+            next_tokens,
+            unfinished_sequences,
+            has_eos_stopping_criteria,
+            pad_token_id,
+            eos_token_id,
+            has_max_length_stopping_criteria,
+            max_length if has_max_length_stopping_criteria else -1,
+        )
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        raise NotImplementedError("AddTokensCheckFinished backward is not implemented")
 
 
 class MuiGenerationMixin(MuiModule, GenerationMixin):
@@ -86,14 +125,31 @@ class MuiGenerationMixin(MuiModule, GenerationMixin):
 
         # init values
         pad_token_id = generation_config._pad_token_tensor
+        eos_token_id = generation_config._eos_token_tensor
+
+        pad_token_id_int = pad_token_id.item() if pad_token_id is not None else -1
+
         output_attentions = generation_config.output_attentions
         output_hidden_states = generation_config.output_hidden_states
         output_scores = generation_config.output_scores
         output_logits = generation_config.output_logits
         return_dict_in_generate = generation_config.return_dict_in_generate
+
+        has_unsupported_stopping_criteria = any(
+            not isinstance(criteria, (EosTokenCriteria, MaxLengthCriteria))
+            for criteria in stopping_criteria
+        )
+
         has_eos_stopping_criteria = any(
             hasattr(criteria, "eos_token_id") for criteria in stopping_criteria
         )
+
+        has_max_length_stopping_criteria = any(
+            hasattr(criteria, "max_length") for criteria in stopping_criteria
+        )
+
+        dispatchable_stopping_criteria = not has_unsupported_stopping_criteria
+
         do_sample = generation_config.do_sample
 
         # init attention / hidden states / scores tuples
@@ -265,7 +321,23 @@ class MuiGenerationMixin(MuiModule, GenerationMixin):
             if tensor_parallelism > 1:
                 next_tokens = comms.broadcast(next_tokens, src=0)
 
-            with record_function("check_stopping_criteria"):
+            # next_tokens is a long tensor of shape [batch_size]
+            # stopping_criteria is typically [EosTokenCriteria, MaxLengthCriteria]
+            # unfinished_sequences is a long tensor of shape [batch_size]
+
+            if dispatchable_stopping_criteria:
+                # call the custom kernel for stopping criteria
+                input_ids, unfinished_sequences = _MuiAddTokensCheckFinished.apply(
+                    input_ids,
+                    next_tokens,
+                    unfinished_sequences,
+                    has_eos_stopping_criteria,
+                    pad_token_id_int,
+                    eos_token_id,
+                    has_max_length_stopping_criteria,
+                    max_length,
+                )
+            else:
                 # finished sentences should have their next token be a padding token
                 if has_eos_stopping_criteria:
                     next_tokens = next_tokens * unfinished_sequences + pad_token_id * (

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
                 "csrc/linear/linear.cu",
                 "csrc/linear/linear_fp16_kernels.cu",
                 "csrc/linear/linear_bf16_kernels.cu",
+                "csrc/embedding/embedding.cu",
+                "csrc/embedding/embedding_xx16_kernels.cu",
                 "csrc/int8_dequantization_kernel.cu",
                 "csrc/int8_linear_kernels.cu",
                 "csrc/ffn/gateup.cu",
@@ -111,6 +113,7 @@ setup(
                 "csrc/parallel_gateupmoe_kernels.cu",
                 # modules
                 "csrc/modules/linear_module.cpp",
+                "csrc/modules/embedding_module.cpp",
                 "csrc/modules/kvcache.cpp",
                 "csrc/modules/static_kvcache.cpp",
                 "csrc/modules/dynamic_kvcache.cpp",

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
                 "csrc/attention/flash_decoding.cu",
                 "csrc/attention/flash_decoding_fp16_kernels.cu",
                 "csrc/attention/flash_decoding_bf16_kernels.cu",
+                "csrc/generation/generation.cu",
                 "csrc/sync.cu",
                 "csrc/sync_torch.cpp",
                 "csrc/reduce/reduce.cu",

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,199 @@
+from typing import List
+from muillm.engineconfig import MuiEngineConfig
+from muillm.modules.embedding import MuiEmbedding
+import torch
+import torch.nn as nn
+
+from muillm.replacement.replacementcontext import MuiReplacementContext
+
+from .test_utils import tensors_equal
+
+
+def random_embedding(
+    num_embeddings: int,
+    embedding_dim: int,
+    padding_idx: int = 0,
+    device="cuda",
+    dtype=torch.float16,
+) -> nn.Embedding:
+    embedding = nn.Embedding(
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        padding_idx=padding_idx,
+        device=device,
+        dtype=dtype,
+    )
+
+    # We seed to have reproducible results
+    torch.manual_seed(0)
+    embedding.weight = nn.Parameter(torch.randn_like(embedding.weight))
+
+    return embedding
+
+
+def copy_embedding(embedding: nn.Embedding):
+    device = embedding.weight.device
+    dtype = embedding.weight.dtype
+    new_embedding = nn.Embedding(
+        num_embeddings=embedding.num_embeddings,
+        embedding_dim=embedding.embedding_dim,
+        padding_idx=embedding.padding_idx,
+        device=device,
+        dtype=dtype,
+    )
+    new_embedding.weight = nn.Parameter(embedding.weight.clone().detach())
+
+    return new_embedding
+
+
+def _test_basic_embedding(
+    input_size=(4, 3),
+    num_embeddings: int = 4,
+    embedding_dim: int = 1024,
+    device: str = "cpu",
+    dtype=torch.float16,
+):
+    embedding = random_embedding(
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        padding_idx=0,
+        device=device,
+        dtype=dtype,
+    )
+
+    # replace destroys the passed embedding module so we need to copy it
+    embedding_copy = copy_embedding(embedding)
+
+    engine_config = MuiEngineConfig(tensor_parallelism=1)
+    replacement_context = MuiReplacementContext(
+        engine_config=engine_config,
+        model=None,  # No model context needed for this test
+        device=device,
+    )
+    muiembedding = MuiEmbedding.replace(
+        replacement_context=replacement_context,
+        prev_module=embedding_copy,
+    )
+    muiembedding.finalize_init()
+
+    input_tensor = torch.randint(
+        low=0, high=num_embeddings, size=input_size, device=device, dtype=torch.int64
+    )
+
+    y = embedding(input_tensor)
+
+    y_m = muiembedding(input_tensor)
+
+    tensors_equal(y, y_m)
+
+
+def test_basic_embedding_fp32_cpu():
+    device = "cpu"
+    input_size = (1,)
+    num_embeddings = 3
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+def test_basic_embedding_fp32_gpu():
+    device = "cuda"
+    input_size = (1,)
+    num_embeddings = 11
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+def test_basic_embedding_fp16_gpu():
+    device = "cuda"
+    input_size = (1,)
+    num_embeddings = 126
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float16,
+    )
+
+
+def test_basic_embedding_bf16_gpu():
+    device = "cuda"
+    input_size = (1,)
+    num_embeddings = 48
+    embedding_dim = 256
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+
+def test_basic_embedding_batched_fp32_cpu():
+    device = "cpu"
+    input_size = (4, 3)
+    num_embeddings = 3
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+def test_basic_embedding_batched_fp32_gpu():
+    device = "cuda"
+    input_size = (4, 3)
+    num_embeddings = 3
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float32,
+    )
+
+
+def test_basic_embedding_batched_fp16_gpu():
+    device = "cuda"
+    input_size = (4, 3)
+    num_embeddings = 3
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.float16,
+    )
+
+
+def test_basic_embedding_batched_bf16_gpu():
+    device = "cuda"
+    input_size = (4, 3)
+    num_embeddings = 3
+    embedding_dim = 128
+    _test_basic_embedding(
+        input_size=input_size,
+        num_embeddings=num_embeddings,
+        embedding_dim=embedding_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )


### PR DESCRIPTION
Using some custom kernels to fuse some operations in the token decoding process as well as plain moving from python to C++ some parts gives a good boost on Llama 3 8B (FP 16 no speculative decoding), now reaching 410 toks/s/user with 4x MI300x instead of 350 toks/s/user previously.

We are still CPU limited, especially at 8x GPUs, and could reach ~500 toks/s/user if managing to have the CPU side fast enough for the GPU to be used.

Llama 3 and Mistral models get those changes.
Llama 4 not yet.